### PR TITLE
Ability to handle special characters in resources names

### DIFF
--- a/IotWeb Portable/Http/HttpResourceHandler.cs
+++ b/IotWeb Portable/Http/HttpResourceHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Reflection;
 
 namespace IotWeb.Common.Http
@@ -17,12 +18,23 @@ namespace IotWeb.Common.Http
             m_defaultFile = defaultFile;
         }
 
+        private static string RequestToNamespace(string uri)
+        {
+            var urlParts = uri.Split('/');
+            var fileName = urlParts.Last();
+            var location = string.Join(".", urlParts.Take(urlParts.Length - 1));
+            var locationNs = location.Replace("@", "_").Replace("-", "_");
+
+            var resourceNs = locationNs + "." + fileName;
+            return resourceNs;
+        }
+
         public void HandleRequest(string uri, HttpRequest request, HttpResponse response, HttpContext context)
         {
             if (request.Method != HttpMethod.Get)
                 throw new HttpMethodNotAllowedException();
-            // Replace '/' with '.' to generate the resource name
-            string resourceName = uri.Replace('/', '.');
+            // Replace '/' with '.' and special characters with _ to generate the resource name
+            string resourceName = RequestToNamespace(uri);
             if (resourceName.StartsWith("."))
                 resourceName = m_prefix + resourceName;
             else


### PR DESCRIPTION
I'm using Angular 2 in my project, which has special characters in resources names.  I suppose if there were unit tests in this project I would add one such that a request to:

@angular/platform-browser-dynamic/platform-browser-dynamic.umd.js

maps to the resource:

_angular.platform_browser_dynamic.platform-browser-dynamic.umd.js
